### PR TITLE
Missing Bottom Co-ordinate for modal backdrops

### DIFF
--- a/bootstrap/modals.styl
+++ b/bootstrap/modals.styl
@@ -64,6 +64,7 @@
   top 0
   right 0
   left 0
+  bottom 0
   background-color $modal-backdrop-bg
 
   // Fade for backdrop


### PR DESCRIPTION
Needed to change this to make my backdrops show. Hope it helps someone else.